### PR TITLE
Add possibility to use Signature V2 for old AWS S3-compatible

### DIFF
--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -95,13 +95,13 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
             title = "Force Signature v4",
             description = "Whether to force use of Signature Version 4 authentication. Default: false",
             defaultValue = "false")
-    private String forceSigV4;
-    
+    private boolean forceSigV4;
+
     @PluginProperty(
             title = "Use Signature v2",
             description = "Use of Signature Version 2 authentication for old container. Default: false",
             defaultValue = "false")
-    private String useSigV2;
+    private boolean useSigV2;
 
     @PluginProperty(
             title = "Use Path Style",
@@ -514,28 +514,17 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
         this.endpoint = endpoint;
     }
 
-    public boolean isSignatureV4Enforced() {
-        if (this.forceSigV4 != null && "true".equals(forceSigV4)) {
-            return true;
-        }
-        return false;
-    }
+    public boolean isSignatureV4Enforced() { return forceSigV4; }
 
-    public void setForceSignatureV4(String forceSigV4) {
+    public void setForceSignatureV4(boolean forceSigV4) {
         this.forceSigV4 = forceSigV4;
     }
-    
-    public boolean isSignatureV2Used() {
-        if (this.useSigV2 != null && "true".equals(useSigV2)) {
-            return true;
-        }
-        return false;
-    }
 
-    public void setUseSignatureV2(String useSigV2) {
+    public boolean isSignatureV2Used() { return useSigV2; }
+
+    public void setUseSignatureV2(boolean useSigV2) {
         this.useSigV2 = useSigV2;
     }
-
 
     protected String resolvedFilepath(final String path, final String filetype) {
         return path + "." + filetype;

--- a/src/test/java/org/rundeck/plugins/S3LogFileStoragePluginTest.java
+++ b/src/test/java/org/rundeck/plugins/S3LogFileStoragePluginTest.java
@@ -415,7 +415,7 @@ public class S3LogFileStoragePluginTest {
         testPlugin.setAWSAccessKeyId("blah");
         testPlugin.setAWSSecretKey("blah");
         testPlugin.setBucket("testBucket");
-        testPlugin.setForceSignatureV4("true");
+        testPlugin.setForceSignatureV4(true);
         testPlugin.initialize(testContext());
         Assert.assertEquals("true",
                 System.getProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY));


### PR DESCRIPTION
I tested the plugin with our Rundeck and we always had the error `The request signature we calculated does not match the signature you provided. Check your key and signing method.`. It was linked with the signature of plugin that use V4 instead of V2, even if the boolean `forceSigV4` was equal to false.
After a lot of search on Internet, it is necessary to force the signer to V2 and send the configuration to Amazon S3 Client.
I added a boolean to indicate exactly which signature version use.