### PR TITLE
Exclude libraries affected by CVEs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 before_cache:
 - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,10 @@ dependencies {
     // add any third-party jar dependencies you wish to include in the plugin
     // using the `pluginLibs` configuration as shown here:
 
-    pluginLibs group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.197'
+    compile "com.amazonaws:aws-java-sdk-s3:1.11.616"
+    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.616') {
+            exclude group: "com.fasterxml.jackson.core"
+    }
 
 
     //the compile dependency won't add the rundeck-core jar to the plugin contents
@@ -103,6 +106,6 @@ jar {
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
-}
+//task wrapper(type: Wrapper) {
+//    gradleVersion = '2.12'
+//}

--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -145,7 +145,11 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
             amazonS3 = createAmazonS3Client();
         }
 
-        Region awsregion = RegionUtils.getRegion(getRegion());
+        Region awsregion = RegionUtils.getRegions().stream()
+            .filter(r -> r.getName().equals(getRegion()))
+            .findAny()
+            .orElse(null);
+
         if (null == awsregion) {
             throw new IllegalArgumentException("Region was not found: " + getRegion());
         }

--- a/src/test/java/org/rundeck/plugins/FailS3.java
+++ b/src/test/java/org/rundeck/plugins/FailS3.java
@@ -2,6 +2,7 @@ package org.rundeck.plugins;
 
 import com.amazonaws.*;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.*;
@@ -20,7 +21,7 @@ import java.util.List;
 /**
 * $INTERFACE is ... User: greg Date: 6/12/13 Time: 7:28 PM
 */
-class FailS3 implements AmazonS3 {
+class FailS3 extends AbstractAmazonS3 {
 
     public void setEndpoint(String endpoint) {
         Assert.fail("unexpected");


### PR DESCRIPTION
This PR:
- Excludes unsecure jackson-databind
- Bumps aws sdk to latest version and fixes api changes from that bump.
- Changes travis image to openjdk8
