### PR TITLE
RUN-577: AWS S3 log storage fails with polish characters username

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Variables in the `path` value include:
 `pathStyle`: Optional, boolean, default=False, set to True if you need to define the bucket in your S3 like endpoint URL. e.g:
  `https://\<s3_like_end_point_url\>/\<your_bucket_name\>`
 
+`metadataUsername`: Optional, boolean, default=True, Set to False if you need to take away the username from metadata sent to the server.
+
 A custom way of defining buckets for your endpoint. Useful for non-AWS S3 like object storage technology e.g [SwiftStack](https://swiftstack.com), Optums, etc. This [background information](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) should be useful.
 
 ## Basic Example (/etc/rundeck/framework.properties)

--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -115,6 +115,12 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
             defaultValue = "false")
     private boolean pathStyle;
 
+    @PluginProperty(
+            title = "Use username in metadata",
+            description = "Include username in metadata sent to the server. Default: true",
+            defaultValue = "true")
+    private boolean metadataUsername;
+
     protected String expandedPath;
 
     public S3LogFileStoragePlugin() {
@@ -414,6 +420,9 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
         ObjectMetadata metadata = new ObjectMetadata();
         for (String s : STORED_META) {
             Object v = context.get(s);
+            if (s.equals(META_USERNAME)) {
+                v = metadataUsername ? v : null;
+            }
             if (null != v) {
                 metadata.addUserMetadata(metaKey(s), isEncodeUserMetadata() ? encodeStringToURLRequest(v.toString()) : v.toString());
             }


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/2168

Fix description:
Added an optional property called 'metadataUsername' if you need to removed the username from the metadata sent to the server