### PR TITLE
RUN-1081: S3 plugin logs errors when a log is greater than 250MiB

### DIFF
--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -1,6 +1,7 @@
 package org.rundeck.plugins;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.PropertiesCredentials;
 import com.amazonaws.regions.Region;
@@ -348,6 +349,8 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
         try {
             amazonS3.putObject(putObjectRequest);
             return true;
+        } catch (SdkClientException e){
+            throw new ExecutionFileStorageException(e.getMessage(), e);
         } catch (AmazonClientException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);
             throw new ExecutionFileStorageException(e.getMessage(), e);

--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -350,6 +350,7 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
             amazonS3.putObject(putObjectRequest);
             return true;
         } catch (SdkClientException e){
+            logger.log(Level.FINE, "Job could still be executing", e.getMessage());
             throw new ExecutionFileStorageException(e.getMessage(), e);
         } catch (AmazonClientException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);


### PR DESCRIPTION
 Fix: [2658](https://github.com/rundeckpro/rundeckpro/issues/2658)

The problem presented is that when we are executing a long lasting job, it is trying to save the logs into the minio bucket without having finished the job execution. So when it tries to save a third or fourth time it is going to throw an exception complaining that the file's length  does not match the one that it is going to upload and that is correct because the job keeps executing.

Hence the approach taken was to catch the exception and let it slipped since it is not causing any problem and it is saving the log into minio after the job is finished. 

![image](https://user-images.githubusercontent.com/29233418/182701912-34113131-eebc-4fc1-9620-4ea36ba70e5a.png)

![image](https://user-images.githubusercontent.com/29233418/182702033-a875e514-b6d6-416c-b962-1b2faa63c603.png)

