### PR TITLE
RSE-812: Fix: not importing logs from s3logstore

### DIFF
--- a/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
+++ b/src/main/java/org/rundeck/plugins/S3LogFileStoragePlugin.java
@@ -41,6 +41,9 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
     public static final String DEFAULT_PATH_FORMAT = "project/${job.project}/${job.execid}";
     public static final String DEFAULT_REGION = "us-east-1";
     public static final String META_EXECID = "execid";
+
+    public static final String META_ID_FOR_LOGSTORE = "execIdForLogStore";
+
     public static final String _PREFIX_META = "rundeck.";
 
     public static final String META_USERNAME = "username";
@@ -188,7 +191,7 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
         if (!configpath.contains("${job.execid}") && configpath.endsWith("/")) {
             configpath = path + "/${job.execid}";
         }
-        expandedPath = expandPath(configpath, context);
+        expandedPath = (context.get("isRemoteFilePath") != null && context.get("isRemoteFilePath").equals("true")) ? String.valueOf(context.get("outputfilepath").toString()) : expandPath(configpath, context);
         if (null == expandedPath || "".equals(expandedPath.trim())) {
             throw new IllegalArgumentException("expanded value of path was empty");
         }
@@ -268,7 +271,7 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
 
     public boolean isAvailable(final String filetype) throws ExecutionFileStorageException {
         HashMap<String, Object> expected = new HashMap<>();
-        expected.put(metaKey(META_EXECID), context.get(META_EXECID));
+        expected.put(metaKey(META_EXECID), context.get(META_ID_FOR_LOGSTORE));
         return isPathAvailable(resolvedFilepath(expandedPath, filetype), expected);
     }
 
@@ -394,7 +397,7 @@ public class S3LogFileStoragePlugin implements ExecutionFileStoragePlugin, AWSCr
         try{
 
             HashMap<String, Object> expected = new HashMap<>();
-            expected.put(metaKey(META_EXECID), context.get(META_EXECID));
+            expected.put(metaKey(META_EXECID), context.get(META_ID_FOR_LOGSTORE));
             String filePath = resolvedFilepath(expandedPath, filetype);
 
             amazonS3.deleteObject(getBucket(), filePath);

--- a/src/test/java/org/rundeck/plugins/S3LogFileStoragePluginTest.java
+++ b/src/test/java/org/rundeck/plugins/S3LogFileStoragePluginTest.java
@@ -64,6 +64,7 @@ public class S3LogFileStoragePluginTest {
     private HashMap<String, Object> testContext() {
         HashMap<String, Object> stringHashMap = new HashMap<String, Object>();
         stringHashMap.put("execid", "testexecid");
+        stringHashMap.put(S3LogFileStoragePlugin.META_ID_FOR_LOGSTORE, "testexecid");
         stringHashMap.put("project", "testproject");
         stringHashMap.put("url", "http://rundeck:4440/execution/5/show");
         stringHashMap.put("serverUrl", "http://rundeck:4440");


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-740
Depends on: https://github.com/rundeck/rundeck/pull/8583

Support the use of `outputfilepath` execution context variable to access log files in case the `isRemoteFilePath` variable is `true`, meaning is an imported execution.