### PR TITLE
RUN-2306: Update AWS sdk version for CVE-2024-21634

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload azure plugin jar
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}

--- a/build.gradle
+++ b/build.gradle
@@ -65,16 +65,15 @@ dependencies {
     // add any third-party jar dependencies you wish to include in the plugin
     // using the `pluginLibs` configuration as shown here:
 
-    implementation "com.amazonaws:aws-java-sdk-s3:1.12.470"
-    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.470') {
+    implementation "com.amazonaws:aws-java-sdk-s3:${awsSdkVersion}"
+    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: "${awsSdkVersion}") {
             exclude group: "com.fasterxml.jackson.core"
             exclude group: "com.fasterxml.jackson.dataformat"
     }
-    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.470') {
+    pluginLibs (group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: "${awsSdkVersion}") {
             exclude group: "com.fasterxml.jackson.core"
             exclude group: "com.fasterxml.jackson.dataformat"
     }
-
 
     //the compile dependency won't add the rundeck-core jar to the plugin contents
     implementation group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 group=org.rundeck.plugins
+awsSdkVersion=1.12.777


### PR DESCRIPTION
Update AWS sdk version to `1.12.777` to remove dependency on `ion-java` library.