### PR TITLE
CVE Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ log files for backups or for cloud-friendly behavior.
 ./gradlew clean build
 ```
 
+**Note**: This plugin has been updated with security fixes for vulnerable dependencies (JUnit 4.13.2, commons-lang3 3.18.0) and updated to use Rundeck Core 5.16.0-20251006 for enhanced security.
+
 ## Installation
 
 1. Copy the `rundeck-s3-log-plugin-x.y.jar` file to the `libext/` directory inside your Rundeck installation. You can find the releases [here](https://github.com/rundeck-plugins/rundeck-s3-log-plugin/releases).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ log files for backups or for cloud-friendly behavior.
 ./gradlew clean build
 ```
 
-**Note**: This plugin has been updated with security fixes for vulnerable dependencies (JUnit 4.13.2, commons-lang3 3.18.0) and updated to use Rundeck Core 5.16.0-20251006 for enhanced security.
+**Note**: This plugin has been updated with security fixes for vulnerable dependencies updated to use Rundeck Core 5.16.0-20251006 and may require that version to work going forward.
 
 ## Installation
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.17.2'
+    id 'pl.allegro.tech.build.axion-release' version "${axionReleaseVersion}"
 }
 defaultTasks 'clean','build'
 apply plugin: 'java'
@@ -42,7 +42,21 @@ repositories {
         // maven snapshot repo since we are using SNAPSHOT of rundeck-core for now
         url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
+}
 
+// Security: Force secure versions of vulnerable dependencies
+configurations.all {
+    resolutionStrategy.force(
+        "junit:junit:${junitVersion}",
+        "org.apache.commons:commons-lang3:${commonsLang3Version}"
+    )
+    
+    // Exclude vulnerable commons-lang 2.x in favor of commons-lang3
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'commons-lang' && details.requested.name == 'commons-lang') {
+            details.useTarget group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3Version
+        }
+    }
 }
 
 configurations{
@@ -71,7 +85,12 @@ dependencies {
 
     //the compile dependency won't add the rundeck-core jar to the plugin contents
     implementation group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion
-    testImplementation group: 'junit', name:'junit', version: '4.11'
+    
+    // Updated JUnit for security fixes
+    testImplementation group: 'junit', name: 'junit', version: junitVersion
+    
+    // Force secure versions of transitive dependencies
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: commonsLang3Version
 }
 
 // task to copy plugin libs to output/lib dir

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,12 @@
 group=org.rundeck.plugins
+
+# Main dependency versions
+rundeckVersion=5.16.0-20251006
 awsSdkVersion=1.12.777
+
+# Security override versions  
+junitVersion=4.13.2
+commonsLang3Version=3.18.0
+
+# Plugin versions
+axionReleaseVersion=1.17.2


### PR DESCRIPTION
Updated gradle.properties with secure dependency versions:

Updated Rundeck Core: 5.14.0-rc1-20250722 → 5.16.0-20251006 Updated JUnit: 4.11 → 4.13.2 (fixes Information Exposure vulnerability) Added commons-lang3: 3.18.0 (replaces vulnerable commons-lang 2.6) Enhanced build.gradle with security overrides:

Added resolutionStrategy.force() to enforce secure versions Implemented dependency replacement strategy to redirect commons-lang:commons-lang → org.apache.commons:commons-lang3 Maintained compatibility with existing AWS SDK version (1.12.777)