### PR TITLE
RUN-4569 Mitigate Jackson CVE-2026-54512/54513

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
     withJavadocJar()
 }
 ext.rundeckPluginVersion= '1.2'
-ext.rundeckVersion='6.0.0-alpha1-20260407'
+ext.rundeckVersion='6.1.0-SNAPSHOT'
 
 /**
  * Set this to a comma-separated list of full classnames of your implemented Rundeck

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=org.rundeck.plugins
 
 # Main dependency versions
-rundeckVersion=6.0.0-alpha1-20260407
+rundeckVersion=6.1.0-SNAPSHOT
 awsSdkVersion=1.12.777
 
 # Security override versions  
@@ -9,4 +9,4 @@ junitVersion=4.13.2
 commonsLang3Version=3.18.0
 
 # Plugin versions
-axionReleaseVersion=1.17.2
+axionReleaseVersion=1.21.2


### PR DESCRIPTION
## Summary
- Bump `rundeck-core` to `6.1.0-SNAPSHOT`, which pulls patched `jackson-databind` 2.22.0 transitively, mitigating CVE-2026-54512 / CVE-2026-54513.
- Standardize the axion-release plugin to 1.21.2.

## Test plan
- [x] `rundeck-core:6.1.0-SNAPSHOT` and `jackson-databind:2.22.0` resolve on compileClasspath (verified locally).
- [ ] CI build and Snyk scan pass on the branch.