### PR TITLE
Fix: don't bundle old slf4j-api from AWS SDK, restoring plugin log output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,10 +107,15 @@ dependencies {
     pluginLibs('software.amazon.awssdk:s3') {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
+        // Don't bundle slf4j-api: the AWS SDK pulls in an old 1.7.x copy that shadows
+        // Rundeck core's own slf4j-api + logging binding in the plugin classloader,
+        // which silently drops all of this plugin's own log output (see issue #85).
+        exclude group: "org.slf4j", module: "slf4j-api"
     }
     pluginLibs('software.amazon.awssdk:sts') {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
+        exclude group: "org.slf4j", module: "slf4j-api"
     }
 
     // rundeck-core: compileOnly for Central POM; testImplementation for tests (not bundled in plugin lib/)


### PR DESCRIPTION
## What
Excludes `org.slf4j:slf4j-api` (pulled in transitively by `software.amazon.awssdk:s3` and `:sts`) from the plugin's bundled `pluginLibs`, so it's no longer copied into `lib/` or listed on the jar's `Class-Path` manifest attribute.

## Why (customer impact)
Reported in #85: users configuring log4j2 for `org.rundeck.amazon.s3.S3LogFileStoragePlugin` got no additional log detail beyond the one core-logged line (`Storage request FAILED`), and saw:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
```

Root cause: the AWS SDK v2 dependency tree pulls in `slf4j-api:1.7.36`, which was being bundled into this plugin's `lib/` folder and referenced on the jar's `Class-Path`. Rundeck's plugin classloader loads a plugin's own bundled libs ahead of core, so this old 1.7.x copy (which uses the legacy `StaticLoggerBinder` lookup) shadowed Rundeck core's own `slf4j-api` + logging binding. As a result the plugin's own logger (`S3LogFileStoragePlugin.logger`) silently fell back to a NOP logger, dropping all of the plugin's own log calls regardless of `log4j2.properties` configuration. The one line users did see comes from Rundeck core's `LogFileStorageService`, not from this plugin.

This mirrors a fix already applied in `git-plugin` and `aws-s3-model-source`, which exclude `slf4j-api` from their bundled AWS/JGit dependencies for the same reason.

## Verification
- `./gradlew dependencies --configuration pluginLibs` no longer resolves `org.slf4j:slf4j-api` (previously resolved to 1.7.36).
- `./gradlew clean build` passes; `build/output/lib` and the built jar's `Class-Path` manifest attribute no longer contain any `slf4j*` jar.
- No behavior change to AWS SDK functionality — only removes a duplicate/shadowing jar from the plugin bundle; the SDK's slf4j calls fall through to Rundeck core's own slf4j-api at runtime.

Fixes #85